### PR TITLE
Remove jax/flax packages during setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN git clone -b sd3 https://github.com/kohya-ss/sd-scripts && \
 # Install main application dependencies
 COPY ./requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r ./requirements.txt
+RUN pip uninstall -y jax jaxlib flax || true
 
 # Install Torch, Torchvision, and Torchaudio for CUDA 12.2
 RUN pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu122/torch_stable.html

--- a/Dockerfile.cuda12.4
+++ b/Dockerfile.cuda12.4
@@ -27,6 +27,7 @@ RUN git clone -b sd3 https://github.com/kohya-ss/sd-scripts && \
 # Install main application dependencies
 COPY ./requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r ./requirements.txt
+RUN pip uninstall -y jax jaxlib flax || true
 
 # Install Torch, Torchvision, and Torchaudio for CUDA 12.4
 RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124

--- a/install.js
+++ b/install.js
@@ -25,6 +25,7 @@ module.exports = {
       params: {
         venv: "env",
         message: [
+          "pip uninstall -y jax jaxlib flax || true",
           "pip uninstall -y diffusers[torch] torch torchaudio torchvision",
           "uv pip install -r requirements.txt",
           "uv pip install -U bitsandbytes"


### PR DESCRIPTION
## Summary
- uninstall jax and flax as part of setup to prevent accidental imports
- apply the uninstall step in Dockerfiles and install.js

## Testing
- `black --check .` *(fails: would reformat app.py)*
- `eslint install.js` *(fails: ESLint couldn't find a configuration file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c5388c0c832fb86eac11afb51f88